### PR TITLE
Set SDKROOT to macosx at project level

### DIFF
--- a/ReactiveTask.xcodeproj/project.pbxproj
+++ b/ReactiveTask.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SDKROOT = macosx;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -361,6 +362,7 @@
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SDKROOT = macosx;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -422,6 +424,7 @@
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SDKROOT = macosx;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -458,6 +461,7 @@
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SDKROOT = macosx;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};


### PR DESCRIPTION
Fixes `carthage build --no-skip-current --platform Mac` failing because of weird iOS targets along the way.

Should resolve https://github.com/Carthage/Carthage/issues/322.

/cc @neilpa