### PR TITLE
Split private dependencies into Cartfile.private

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,2 @@
 github "ReactiveCocoa/ReactiveCocoa" "swift-development"
-github "Quick/Quick" == 0.2.0
-github "Quick/Nimble"
 github "Carthage/LlamaKit" == 0.1.1
-github "jspahrsummers/xcconfigs" >= 0.6

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,3 @@
+github "Quick/Quick" == 0.2.0
+github "Quick/Nimble"
+github "jspahrsummers/xcconfigs" >= 0.6


### PR DESCRIPTION
These shouldn’t be exported to consumers of ReactiveTask.