### PR TITLE
Add `DebugSinkOf`

### DIFF
--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -12,9 +12,9 @@ import ReactiveCocoa
 import Result
 
 #if DEBUG
-public typealias SinkOfNSData = DebugSinkOf<NSData>
+public typealias DataSink = DebugSinkOf<NSData>
 #else
-public typealias SinkOfNSData = SinkOf<NSData>
+public typealias DataSink = SinkOf<NSData>
 #endif
 
 /// Describes how to execute a shell command.
@@ -194,7 +194,7 @@ private final class Pipe {
 ///
 /// If `forwardingSink` is non-nil, each incremental piece of data will be sent
 /// to it as data is received.
-private func aggregateDataReadFromPipe(pipe: Pipe, forwardingSink: SinkOfNSData?) -> SignalProducer<NSData, ReactiveTaskError> {
+private func aggregateDataReadFromPipe(pipe: Pipe, forwardingSink: DataSink?) -> SignalProducer<NSData, ReactiveTaskError> {
 	let readProducer = pipe.transferReadsToProducer()
 
 	return SignalProducer { observer, disposable in
@@ -232,7 +232,7 @@ private func aggregateDataReadFromPipe(pipe: Pipe, forwardingSink: SinkOfNSData?
 /// Returns a producer that will launch the task when started, then send one
 /// `NSData` value (representing aggregated data from `stdout`) and complete
 /// upon success.
-public func launchTask(taskDescription: TaskDescription, standardOutput: SinkOfNSData? = nil, standardError: SinkOfNSData? = nil) -> SignalProducer<NSData, ReactiveTaskError> {
+public func launchTask(taskDescription: TaskDescription, standardOutput: DataSink? = nil, standardError: DataSink? = nil) -> SignalProducer<NSData, ReactiveTaskError> {
 	return SignalProducer { observer, disposable in
 		let task = NSTask()
 		task.launchPath = taskDescription.launchPath

--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -11,6 +11,12 @@ import Foundation
 import ReactiveCocoa
 import Result
 
+#if DEBUG
+public typealias SinkOfNSData = DebugSinkOf<NSData>
+#else
+public typealias SinkOfNSData = SinkOf<NSData>
+#endif
+
 /// Describes how to execute a shell command.
 public struct TaskDescription {
 	/// The path to the executable that should be launched.
@@ -188,7 +194,7 @@ private final class Pipe {
 ///
 /// If `forwardingSink` is non-nil, each incremental piece of data will be sent
 /// to it as data is received.
-private func aggregateDataReadFromPipe(pipe: Pipe, forwardingSink: SinkOf<NSData>?) -> SignalProducer<NSData, ReactiveTaskError> {
+private func aggregateDataReadFromPipe(pipe: Pipe, forwardingSink: SinkOfNSData?) -> SignalProducer<NSData, ReactiveTaskError> {
 	let readProducer = pipe.transferReadsToProducer()
 
 	return SignalProducer { observer, disposable in
@@ -226,7 +232,7 @@ private func aggregateDataReadFromPipe(pipe: Pipe, forwardingSink: SinkOf<NSData
 /// Returns a producer that will launch the task when started, then send one
 /// `NSData` value (representing aggregated data from `stdout`) and complete
 /// upon success.
-public func launchTask(taskDescription: TaskDescription, standardOutput: SinkOf<NSData>? = nil, standardError: SinkOf<NSData>? = nil) -> SignalProducer<NSData, ReactiveTaskError> {
+public func launchTask(taskDescription: TaskDescription, standardOutput: SinkOfNSData? = nil, standardError: SinkOfNSData? = nil) -> SignalProducer<NSData, ReactiveTaskError> {
 	return SignalProducer { observer, disposable in
 		let task = NSTask()
 		task.launchPath = taskDescription.launchPath

--- a/ReactiveTaskTests/TaskSpec.swift
+++ b/ReactiveTaskTests/TaskSpec.swift
@@ -23,7 +23,7 @@ class TaskSpec: QuickSpec {
 			standardError.value = NSData()
 		}
 
-		func accumulatingSinkForProperty(property: MutableProperty<NSData>) -> SinkOf<NSData> {
+		func accumulatingSinkForProperty(property: MutableProperty<NSData>) -> SinkOfNSData {
 			let (signal, sink) = Signal<NSData, NoError>.pipe()
 
 			property <~ signal
@@ -34,7 +34,7 @@ class TaskSpec: QuickSpec {
 							return buffer
 						}
 
-			return SinkOf { data in
+			return SinkOfNSData { data in
 				sendNext(sink, data)
 			}
 		}

--- a/ReactiveTaskTests/TaskSpec.swift
+++ b/ReactiveTaskTests/TaskSpec.swift
@@ -23,7 +23,7 @@ class TaskSpec: QuickSpec {
 			standardError.value = NSData()
 		}
 
-		func accumulatingSinkForProperty(property: MutableProperty<NSData>) -> SinkOfNSData {
+		func accumulatingSinkForProperty(property: MutableProperty<NSData>) -> DataSink {
 			let (signal, sink) = Signal<NSData, NoError>.pipe()
 
 			property <~ signal
@@ -34,7 +34,7 @@ class TaskSpec: QuickSpec {
 							return buffer
 						}
 
-			return SinkOfNSData { data in
+			return DataSink { data in
 				sendNext(sink, data)
 			}
 		}


### PR DESCRIPTION
Xcode debugger can't step into `SinkType.put()`.
Using `DebugSinkOf` instead of `SinkOf` allow step into `SinkType.put()`

https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2021