### PR TITLE
Replace incremental data sinks with a single stream of TaskEvent enums

### DIFF
--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -317,6 +317,16 @@ extension TaskEvent: Printable {
 	}
 }
 
+/// Ignores incremental standard output and standard error data from the given
+/// task, sending only a single value with the final, aggregated result.
+public func ignoreTaskData<T, Error>(signal: Signal<TaskEvent<T>, Error>) -> Signal<T, Error> {
+	return signal
+		|> map { event in
+			return event.value.map { $0 }
+		}
+		|> ignoreNil
+}
+
 /// Launches a new shell task, using the parameters from `taskDescription`.
 ///
 /// Returns a producer that will launch the task when started, then send

--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -266,6 +266,20 @@ public enum TaskEvent<T> {
 			return box.value
 		}
 	}
+
+	/// Maps over the value embedded in a `Success` event.
+	public func map<U>(transform: T -> U) -> TaskEvent<U> {
+		switch self {
+		case let .StandardOutput(data):
+			return .StandardOutput(data)
+
+		case let .StandardError(data):
+			return .StandardError(data)
+
+		case let .Success(box):
+			return .Success(box.map(transform))
+		}
+	}
 }
 
 public func == <T: Equatable>(lhs: TaskEvent<T>, rhs: TaskEvent<T>) -> Bool {

--- a/ReactiveTaskTests/TaskSpec.swift
+++ b/ReactiveTaskTests/TaskSpec.swift
@@ -15,60 +15,61 @@ import Result
 
 class TaskSpec: QuickSpec {
 	override func spec() {
-		let standardOutput = MutableProperty(NSData())
-		let standardError = MutableProperty(NSData())
+		it("should launch a task that writes to stdout") {
+			let result = launchTask(TaskDescription(launchPath: "/bin/echo", arguments: [ "foobar" ]))
+				|> reduce(NSMutableData()) { aggregated, event in
+					switch event {
+					case let .StandardOutput(data):
+						aggregated.appendData(data)
 
-		beforeEach {
-			standardOutput.value = NSData()
-			standardError.value = NSData()
-		}
+					default:
+						break
+					}
 
-		func accumulatingSinkForProperty(property: MutableProperty<NSData>) -> SinkOf<NSData> {
-			let (signal, sink) = Signal<NSData, NoError>.pipe()
+					return aggregated
+				}
+				|> single
 
-			property <~ signal
-						|> scan(NSData()) { (accum, data) in
-							let buffer = accum.mutableCopy() as! NSMutableData
-							buffer.appendData(data)
-
-							return buffer
-						}
-
-			return SinkOf { data in
-				sendNext(sink, data)
+			expect(result).notTo(beNil())
+			if let data = result?.value {
+				expect(NSString(data: data, encoding: NSUTF8StringEncoding)).to(equal("foobar\n"))
 			}
 		}
 
-		it("should launch a task that writes to stdout") {
-			let desc = TaskDescription(launchPath: "/bin/echo", arguments: [ "foobar" ])
-			let task = launchTask(desc, standardOutput: accumulatingSinkForProperty(standardOutput))
-			expect(standardOutput.value).to(equal(NSData()))
-
-			let result = task |> wait
-			expect(result.value).notTo(beNil())
-			expect(NSString(data: standardOutput.value, encoding: NSUTF8StringEncoding)).to(equal("foobar\n"))
-		}
-
 		it("should launch a task that writes to stderr") {
-			let desc = TaskDescription(launchPath: "/usr/bin/stat", arguments: [ "not-a-real-file" ])
-			let task = launchTask(desc, standardError: accumulatingSinkForProperty(standardError))
-			expect(standardError.value).to(equal(NSData()))
+			let result = launchTask(TaskDescription(launchPath: "/usr/bin/stat", arguments: [ "not-a-real-file" ]))
+				|> reduce(NSMutableData()) { aggregated, event in
+					switch event {
+					case let .StandardError(data):
+						aggregated.appendData(data)
 
-			let result = task |> wait
-			expect(result.value).to(beNil())
-			expect(NSString(data: standardError.value, encoding: NSUTF8StringEncoding)).to(equal("stat: not-a-real-file: stat: No such file or directory\n"))
+					default:
+						break
+					}
+
+					return aggregated
+				}
+				|> single
+
+			expect(result).notTo(beNil())
+			if let data = result?.value {
+				expect(NSString(data: data, encoding: NSUTF8StringEncoding)).to(equal("stat: not-a-real-file: stat: No such file or directory\n"))
+			}
 		}
 
 		it("should launch a task with standard input") {
 			let strings = [ "foo\n", "bar\n", "buzz\n", "fuzz\n" ]
 			let data = strings.map { $0.dataUsingEncoding(NSUTF8StringEncoding)! }
 
-			let desc = TaskDescription(launchPath: "/usr/bin/sort", standardInput: SignalProducer(values: data))
-			let task = launchTask(desc, standardOutput: accumulatingSinkForProperty(standardOutput))
+			let result = launchTask(TaskDescription(launchPath: "/usr/bin/sort", standardInput: SignalProducer(values: data)))
+				|> map { event in event.value }
+				|> ignoreNil
+				|> single
 
-			let result = task |> wait
-			expect(result.value).notTo(beNil())
-			expect(NSString(data: standardOutput.value, encoding: NSUTF8StringEncoding)).to(equal("bar\nbuzz\nfoo\nfuzz\n"))
+			expect(result).notTo(beNil())
+			if let data = result?.value {
+				expect(NSString(data: data, encoding: NSUTF8StringEncoding)).to(equal("bar\nbuzz\nfoo\nfuzz\n"))
+			}
 		}
 	}
 }


### PR DESCRIPTION
~~_Depends on #22._~~

This is a refactoring that should've been done when we first moved from `ColdSignal` + `HotSignal` to `SignalProducer` + `Signal`.

The current sink-focused implementation bifurcates logic, and makes it really easy to introduce issues like that fixed by https://github.com/Carthage/ReactiveTask/pull/21. Handling everything within the same stream should make behavior more deterministic.