### PR TITLE
Fix a heap overflow detected by Address Sanitizer

### DIFF
--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -480,7 +480,7 @@ public func launchTask(taskDescription: TaskDescription) -> SignalProducer<TaskE
 							disposable += stdoutAggregated
 								|> then(stderrAggregated)
 								|> flatMap(.Concat) { data in
-									let errorString = (data.length > 0 ? String(UTF8String: UnsafePointer<CChar>(data.bytes)) : nil)
+									let errorString = (data.length > 0 ? NSString(data: data, encoding: NSUTF8StringEncoding) as? String : nil)
 									return SignalProducer(error: .ShellTaskFailed(exitCode: terminationStatus, standardError: errorString))
 								}
 								|> start(observer)


### PR DESCRIPTION
Running my project with Address Sanitizer enabled, it detected a heap overflow here. I haven't delved into what the exact cause is, but using NSString's init?(data:encoding) rather than String's init(UTF8String) eliminates the problem.