### PR TITLE
Simplify some naming

### DIFF
--- a/ReactiveTask/Errors.swift
+++ b/ReactiveTask/Errors.swift
@@ -10,7 +10,7 @@ import Foundation
 import ReactiveCocoa
 
 /// An error originating from ReactiveTask.
-public enum ReactiveTaskError: ErrorType {
+public enum TaskError: ErrorType {
 	/// A shell task exited unsuccessfully.
 	case ShellTaskFailed(exitCode: Int32, standardError: String?)
 
@@ -18,7 +18,7 @@ public enum ReactiveTaskError: ErrorType {
 	case POSIXError(Int32)
 }
 
-extension ReactiveTaskError: CustomStringConvertible {
+extension TaskError: CustomStringConvertible {
 	public var description: String {
 		switch self {
 		case let .ShellTaskFailed(exitCode, standardError):

--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -54,9 +54,7 @@ public struct Task {
 
 extension Task: CustomStringConvertible {
 	public var description: String {
-		return arguments.reduce(launchPath) { str, arg in
-			return str + " \(arg)"
-		}
+		return "\(launchPath) \(arguments.joinWithSeparator(" "))"
 	}
 }
 

--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -52,6 +52,36 @@ extension Task: CustomStringConvertible {
 	}
 }
 
+extension Task: Hashable {
+	public var hashValue: Int {
+		var result = launchPath.hashValue ^ (workingDirectoryPath?.hashValue ?? 0)
+		for argument in arguments {
+			result ^= argument.hashValue
+		}
+		for (key, value) in environment ?? [:] {
+			result ^= key.hashValue ^ value.hashValue
+		}
+		return result
+	}
+}
+
+private func ==<Key : Equatable, Value : Equatable>(lhs: [Key : Value]?, rhs: [Key : Value]?) -> Bool {
+	switch (lhs, rhs) {
+	case let (.Some(lhs), .Some(rhs)):
+		return lhs == rhs
+		
+	case (.None, .None):
+		return true
+		
+	default:
+		return false
+	}
+}
+
+public func ==(lhs: Task, rhs: Task) -> Bool {
+	return lhs.launchPath == rhs.launchPath && lhs.arguments == rhs.arguments && lhs.workingDirectoryPath == rhs.workingDirectoryPath && lhs.environment == rhs.environment
+}
+
 /// A private class used to encapsulate a Unix pipe.
 private final class Pipe {
 	/// The file descriptor for reading data.

--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -430,11 +430,12 @@ extension Signal where Value: TaskEventType {
 
 /// Launches a new shell task.
 ///
-/// taskDescription - The task to launch.
-/// standardInput   - Data to stream to standard input of the launched process. If nil, stdin will
-///                   be inherited from the parent process.
+/// - Parameters:
+///   - taskDescription: The task to launch.
+///   - standardInput:   Data to stream to standard input of the launched process. If nil, stdin will
+///                      be inherited from the parent process.
 ///
-/// Returns a producer that will launch the task when started, then send
+/// - Returns: A producer that will launch the task when started, then send
 /// `TaskEvent`s as execution proceeds.
 public func launchTask(taskDescription: Task, standardInput: SignalProducer<NSData, NoError>? = nil) -> SignalProducer<TaskEvent<NSData>, TaskError> {
 	return SignalProducer { observer, disposable in

--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -67,7 +67,7 @@ extension Task: Hashable {
 
 private func ==<Key: Equatable, Value: Equatable>(lhs: [Key: Value]?, rhs: [Key: Value]?) -> Bool {
 	switch (lhs, rhs) {
-	case let (.Some(lhs), .Some(rhs)):
+	case let (lhs?, rhs?):
 		return lhs == rhs
 		
 	case (.None, .None):

--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -35,7 +35,7 @@ public struct Task {
 	/// If nil, stdin will be inherited from the parent process.
 	public var standardInput: SignalProducer<NSData, NoError>?
 
-	public init(launchPath: String, arguments: [String] = [], workingDirectoryPath: String? = nil, environment: [String: String]? = nil, standardInput: SignalProducer<NSData, NoError>? = nil) {
+	public init(_ launchPath: String, arguments: [String] = [], workingDirectoryPath: String? = nil, environment: [String: String]? = nil, standardInput: SignalProducer<NSData, NoError>? = nil) {
 		self.launchPath = launchPath
 		self.arguments = arguments
 		self.workingDirectoryPath = workingDirectoryPath

--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -65,7 +65,7 @@ extension Task: Hashable {
 	}
 }
 
-private func ==<Key : Equatable, Value : Equatable>(lhs: [Key : Value]?, rhs: [Key : Value]?) -> Bool {
+private func ==<Key: Equatable, Value: Equatable>(lhs: [Key: Value]?, rhs: [Key: Value]?) -> Bool {
 	switch (lhs, rhs) {
 	case let (.Some(lhs), .Some(rhs)):
 		return lhs == rhs

--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -11,7 +11,7 @@ import ReactiveCocoa
 import Result
 
 /// Describes how to execute a shell command.
-public struct TaskDescription {
+public struct Task {
 	/// The path to the executable that should be launched.
 	public var launchPath: String
 
@@ -48,11 +48,11 @@ public struct TaskDescription {
 	
 	/// wait for all task termination
 	public static func waitForAllTaskTermination() {
-		dispatch_group_wait(TaskDescription.group, DISPATCH_TIME_FOREVER)
+		dispatch_group_wait(Task.group, DISPATCH_TIME_FOREVER)
 	}
 }
 
-extension TaskDescription: CustomStringConvertible {
+extension Task: CustomStringConvertible {
 	public var description: String {
 		return arguments.reduce(launchPath) { str, arg in
 			return str + " \(arg)"
@@ -395,10 +395,10 @@ extension Signal where Value: TaskEventType {
 ///
 /// Returns a producer that will launch the task when started, then send
 /// `TaskEvent`s as execution proceeds.
-public func launchTask(taskDescription: TaskDescription) -> SignalProducer<TaskEvent<NSData>, ReactiveTaskError> {
+public func launchTask(taskDescription: Task) -> SignalProducer<TaskEvent<NSData>, ReactiveTaskError> {
 	return SignalProducer { observer, disposable in
 		let queue = dispatch_queue_create(taskDescription.description, DISPATCH_QUEUE_SERIAL)
-		let group = TaskDescription.group
+		let group = Task.group
 
 		let task = NSTask()
 		task.launchPath = taskDescription.launchPath

--- a/ReactiveTaskTests/TaskSpec.swift
+++ b/ReactiveTaskTests/TaskSpec.swift
@@ -16,7 +16,7 @@ import Result
 class TaskSpec: QuickSpec {
 	override func spec() {
 		it("should launch a task that writes to stdout") {
-			let result = launchTask(Task(launchPath: "/bin/echo", arguments: [ "foobar" ]))
+			let result = launchTask(Task("/bin/echo", arguments: [ "foobar" ]))
 				.reduce(NSMutableData()) { aggregated, event in
 					switch event {
 					case let .StandardOutput(data):
@@ -37,7 +37,7 @@ class TaskSpec: QuickSpec {
 		}
 
 		it("should launch a task that writes to stderr") {
-			let result = launchTask(Task(launchPath: "/usr/bin/stat", arguments: [ "not-a-real-file" ]))
+			let result = launchTask(Task("/usr/bin/stat", arguments: [ "not-a-real-file" ]))
 				.reduce(NSMutableData()) { aggregated, event in
 					switch event {
 					case let .StandardError(data):
@@ -61,7 +61,7 @@ class TaskSpec: QuickSpec {
 			let strings = [ "foo\n", "bar\n", "buzz\n", "fuzz\n" ]
 			let data = strings.map { $0.dataUsingEncoding(NSUTF8StringEncoding)! }
 
-			let result = launchTask(Task(launchPath: "/usr/bin/sort", standardInput: SignalProducer(values: data)))
+			let result = launchTask(Task("/usr/bin/sort", standardInput: SignalProducer(values: data)))
 				.map { event in event.value }
 				.ignoreNil()
 				.single()

--- a/ReactiveTaskTests/TaskSpec.swift
+++ b/ReactiveTaskTests/TaskSpec.swift
@@ -61,7 +61,7 @@ class TaskSpec: QuickSpec {
 			let strings = [ "foo\n", "bar\n", "buzz\n", "fuzz\n" ]
 			let data = strings.map { $0.dataUsingEncoding(NSUTF8StringEncoding)! }
 
-			let result = launchTask(Task("/usr/bin/sort", standardInput: SignalProducer(values: data)))
+			let result = launchTask(Task("/usr/bin/sort"), standardInput: SignalProducer(values: data))
 				.map { event in event.value }
 				.ignoreNil()
 				.single()

--- a/ReactiveTaskTests/TaskSpec.swift
+++ b/ReactiveTaskTests/TaskSpec.swift
@@ -16,7 +16,7 @@ import Result
 class TaskSpec: QuickSpec {
 	override func spec() {
 		it("should launch a task that writes to stdout") {
-			let result = launchTask(TaskDescription(launchPath: "/bin/echo", arguments: [ "foobar" ]))
+			let result = launchTask(Task(launchPath: "/bin/echo", arguments: [ "foobar" ]))
 				.reduce(NSMutableData()) { aggregated, event in
 					switch event {
 					case let .StandardOutput(data):
@@ -37,7 +37,7 @@ class TaskSpec: QuickSpec {
 		}
 
 		it("should launch a task that writes to stderr") {
-			let result = launchTask(TaskDescription(launchPath: "/usr/bin/stat", arguments: [ "not-a-real-file" ]))
+			let result = launchTask(Task(launchPath: "/usr/bin/stat", arguments: [ "not-a-real-file" ]))
 				.reduce(NSMutableData()) { aggregated, event in
 					switch event {
 					case let .StandardError(data):
@@ -61,7 +61,7 @@ class TaskSpec: QuickSpec {
 			let strings = [ "foo\n", "bar\n", "buzz\n", "fuzz\n" ]
 			let data = strings.map { $0.dataUsingEncoding(NSUTF8StringEncoding)! }
 
-			let result = launchTask(TaskDescription(launchPath: "/usr/bin/sort", standardInput: SignalProducer(values: data)))
+			let result = launchTask(Task(launchPath: "/usr/bin/sort", standardInput: SignalProducer(values: data)))
 				.map { event in event.value }
 				.ignoreNil()
 				.single()


### PR DESCRIPTION
I really dislike some of the current naming in ReactiveTask. This PR cleans that up and makes a few more breaking changes while I'm at it:

- Rename `TaskDescription` to `Task`
- Remove the `launchPath:` parameter name from `Task.init`
- Rename `ReactiveTaskError` to `TaskError`
- Move `standardInput` from `Task` to `launchTask`
- Make `Task` conform to `Hashable`
- Add a `Launch` case to `TaskEvent` that sends the `Task`

The latter 3 changes were motivated by a desire to print executed commands in Carthage. Right now, we only print the output of commands. It'd be nice to print the commands themselves.