### PR TITLE
Fix racy test failure

### DIFF
--- a/ReactiveTask/Task.swift
+++ b/ReactiveTask/Task.swift
@@ -520,9 +520,7 @@ extension Task {
 						close(stdoutPipe.writeFD)
 						close(stderrPipe.writeFD)
 
-						stdinProducer.startWithSignal { signal, signalDisposable in
-							disposable += signalDisposable
-						}
+						disposable += stdinProducer.start()
 
 						let _ = disposable.add {
 							process.terminate()


### PR DESCRIPTION
With thanks to @andersio for doing most of the work.

Without an observer, the unretained signal interrupts. This attempts to cancel the `DispatchIO`, which can prevent the input from being written.