### PR TITLE
[Package.swift] Add `.git` suffix to dependency urls consistently

### DIFF
--- a/.Package.test.swift
+++ b/.Package.test.swift
@@ -3,8 +3,8 @@ import PackageDescription
 let package = Package(
     name: "ReactiveTask",
     dependencies: [
-        .Package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", majorVersion: 1),
-        .Package(url: "https://github.com/Quick/Quick", majorVersion: 1, minor: 1),
-        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 6),
+        .Package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", majorVersion: 1),
+        .Package(url: "https://github.com/Quick/Quick.git", majorVersion: 1, minor: 1),
+        .Package(url: "https://github.com/Quick/Nimble.git", majorVersion: 6),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,6 @@ import PackageDescription
 let package = Package(
     name: "ReactiveTask",
     dependencies: [
-        .Package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", majorVersion: 1),
+        .Package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", majorVersion: 1),
     ]
 )


### PR DESCRIPTION
Rationale: https://github.com/kylef/Stencil/issues/101 and https://github.com/kylef/Stencil/pull/84