### PR TITLE
Escape NULL terminator in strings with correct glyph

### DIFF
--- a/Sources/Task.swift
+++ b/Sources/Task.swift
@@ -54,7 +54,7 @@ extension String {
 			in: self,
 			range: NSRange(location: 0, length: self.utf16.count),
 			withTemplate: "\\\\$0"
-		)
+		).replacingOccurrences(of: "\0", with: "␀")
 	}
 }
 

--- a/Tests/ReactiveTaskTests/StringExtensionSpec.swift
+++ b/Tests/ReactiveTaskTests/StringExtensionSpec.swift
@@ -10,6 +10,10 @@ class StringExtensionSpec: QuickSpec {
 				expect("d\te\tf".escapingWhitespaces).to(equal("d\\\te\\\tf"))
 			}
 
+			it("should escape the NULL terminator with the 'symbol for null' glyph (U+2400)") {
+				expect("abc\0".escapingWhitespaces).to(equal("abc␀"))
+			}
+			
 			it("should not change the original string if it does not contain whitespaces") {
 				expect("ReactiveTask").to(equal("ReactiveTask"))
 			}


### PR DESCRIPTION
As discussed in https://github.com/Carthage/Carthage/pull/2252#issuecomment-344060192

Two questions:
* The function is currently called `escapingWhitespaces`. Should we rename it or could NULL be considered a Whitespace?
* I've used the glyph directly (␀) - is this fine or is it better to use the unicode codepoint? (`U+2400`)?

@jdhealy 